### PR TITLE
Add time interval editing modal to tracker tasks

### DIFF
--- a/examples/tapme/css/components/icon-button.css
+++ b/examples/tapme/css/components/icon-button.css
@@ -31,6 +31,22 @@
   fill: var(--white);
 }
 
+.icon-button:disabled,
+.icon-button:disabled:hover {
+  cursor: not-allowed;
+  background-color: transparent;
+  color: rgba(28, 29, 31, 0.35);
+}
+
+.icon-button:disabled svg * {
+  fill: currentColor;
+}
+
+body:has(.page--dark) .icon-button:disabled,
+body:has(.page--dark) .icon-button:disabled:hover {
+  color: rgba(230, 237, 243, 0.35);
+}
+
 /*Variants*/
 
 .icon-button--big {

--- a/examples/tapme/css/components/index.css
+++ b/examples/tapme/css/components/index.css
@@ -6,6 +6,7 @@
 @import "tab-panel.component.css";
 @import "switcher.component.css";
 @import "modal-window.component.css";
+@import "task-intervals.modal-window.component.css";
 @import "switch-theme.component.css";
 @import "error.modal.component.css";
 @import "chart.buttons-panel.component.css";

--- a/examples/tapme/css/components/task-intervals.modal-window.component.css
+++ b/examples/tapme/css/components/task-intervals.modal-window.component.css
@@ -1,0 +1,185 @@
+.task-intervals-modal {
+    width: min(680px, 90vw);
+    margin: auto;
+    border: none;
+    border-radius: 16px;
+    padding: 0;
+    box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+    color: #1C1D1F;
+}
+
+.task-intervals-modal::backdrop {
+    background: transparent;
+}
+
+.task-intervals-modal__form {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    padding: 28px 32px 32px;
+    background: var(--white);
+    border-radius: 16px;
+    font-family: Arial;
+}
+
+.task-intervals-modal__header h1 {
+    margin: 0;
+    font-size: 26px;
+}
+
+.task-intervals-modal__task {
+    margin: 6px 0 0;
+    font-size: 16px;
+    color: rgba(28, 29, 31, 0.72);
+}
+
+.task-intervals-modal__task span {
+    font-weight: 600;
+}
+
+.task-intervals-modal__subtitle {
+    margin: 6px 0 0;
+    color: rgba(28, 29, 31, 0.7);
+    font-size: 14px;
+}
+
+.task-intervals-modal__content {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    max-height: 420px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
+.task-intervals-modal__interval {
+    border: 1px solid rgba(28, 29, 31, 0.1);
+    border-radius: 12px;
+    padding: 16px;
+    background: rgba(255, 255, 255, 0.6);
+}
+
+.task-intervals-modal__interval h2 {
+    margin: 0 0 12px;
+    font-size: 18px;
+    font-weight: 600;
+}
+
+.task-intervals-modal__fields {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.task-intervals-modal__field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 14px;
+}
+
+.task-intervals-modal__field input {
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid rgba(28, 29, 31, 0.25);
+    font-size: 14px;
+    background: rgba(255, 255, 255, 0.92);
+    color: inherit;
+}
+
+.task-intervals-modal__field input:focus {
+    outline: 2px solid rgba(81, 164, 7, 0.45);
+}
+
+.task-intervals-modal__error {
+    margin: 12px 0 0;
+    color: #9E0C0C;
+    font-size: 13px;
+}
+
+.task-intervals-modal__empty {
+    margin: 0;
+    font-size: 15px;
+    color: rgba(28, 29, 31, 0.7);
+}
+
+.task-intervals-modal__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.task-intervals-modal__button {
+    min-width: 120px;
+    padding: 12px 18px;
+    border-radius: 8px;
+    border: none;
+    font-size: 15px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task-intervals-modal__button--secondary {
+    background: transparent;
+    color: rgba(28, 29, 31, 0.8);
+    box-shadow: inset 0 0 0 1px rgba(28, 29, 31, 0.2);
+}
+
+.task-intervals-modal__button--secondary:hover {
+    background: rgba(28, 29, 31, 0.06);
+}
+
+.task-intervals-modal__button--primary {
+    background: #51A407;
+    color: var(--white);
+    box-shadow: 0 8px 16px rgba(81, 164, 7, 0.25);
+}
+
+.task-intervals-modal__button--primary:hover {
+    background: #3C7D05;
+}
+
+body:has(.page--dark) .task-intervals-modal {
+    color: var(--white);
+}
+
+body:has(.page--dark) .task-intervals-modal__form {
+    background: var(--black);
+}
+
+body:has(.page--dark) .task-intervals-modal__task {
+    color: rgba(230, 237, 243, 0.7);
+}
+
+body:has(.page--dark) .task-intervals-modal__subtitle,
+body:has(.page--dark) .task-intervals-modal__empty {
+    color: rgba(230, 237, 243, 0.7);
+}
+
+body:has(.page--dark) .task-intervals-modal__interval {
+    background: rgba(28, 29, 31, 0.65);
+    border-color: rgba(230, 237, 243, 0.2);
+}
+
+body:has(.page--dark) .task-intervals-modal__field input {
+    background: rgba(28, 29, 31, 0.85);
+    border-color: rgba(230, 237, 243, 0.25);
+    color: var(--white);
+}
+
+body:has(.page--dark) .task-intervals-modal__field input:focus {
+    outline-color: rgba(81, 164, 7, 0.65);
+}
+
+body:has(.page--dark) .task-intervals-modal__button--secondary {
+    color: rgba(230, 237, 243, 0.85);
+    box-shadow: inset 0 0 0 1px rgba(230, 237, 243, 0.3);
+}
+
+body:has(.page--dark) .task-intervals-modal__button--secondary:hover {
+    background: rgba(230, 237, 243, 0.08);
+}
+
+body:has(.page--dark) .task-intervals-modal__error {
+    color: #F88C8C;
+}

--- a/examples/tapme/index.html
+++ b/examples/tapme/index.html
@@ -80,6 +80,7 @@
         <script src="./js/shared/components/blur.component.js"></script>
 
         <script src="./js/pages/tracker/components/modal-windows/delete-modal-window.component.js"></script>
+        <script src="./js/pages/tracker/components/modal-windows/task-intervals.modal-window.component.js"></script>
 
         <!--import theme components-->
         <script src="js/shared/components/change-language.component.js"></script>
@@ -101,6 +102,7 @@
         <script src="./js/pages/tracker/components/task/task.save-as-preset-button.component.js"></script>
         <script src="./js/pages/tracker/components/task/task.toggle-button.component.js"></script>
         <script src="./js/pages/tracker/components/task/task.text.component.js"></script>
+        <script src="./js/pages/tracker/components/task/task.edit-intervals-button.component.js"></script>
         <script src="./js/pages/tracker/components/task/task.component.js"></script>
         <script src="./js/pages/tracker/components/task/tasks-list.component.js"></script>
 

--- a/examples/tapme/js/pages/tracker/components/modal-windows/task-intervals.modal-window.component.js
+++ b/examples/tapme/js/pages/tracker/components/modal-windows/task-intervals.modal-window.component.js
@@ -1,0 +1,212 @@
+class TaskIntervalsModalWindowComponent extends Component {
+    /**
+     * @param {{ task: TaskModel }} params
+     */
+    constructor({ task }) {
+        super();
+
+        this.task = task;
+        this.dialogTitleId = getId();
+        this.formId = getId();
+        this.intervals = task._finishedIntervals.map((interval, index) => ({
+            id: `${task.id}-${index}-${getId()}`,
+            startedAt: this._formatDateForInput(interval.startedAt),
+            finishedAt: this._formatDateForInput(interval.finishedAt),
+            error: undefined,
+        }));
+
+        this.subscribe(languageModel.language).redrawOnChange();
+    }
+
+    _formatDateForInput(date) {
+        if (!date) {
+            return '';
+        }
+
+        const year = date.getFullYear();
+        const month = `${date.getMonth() + 1}`.padStart(2, '0');
+        const day = `${date.getDate()}`.padStart(2, '0');
+        const hours = `${date.getHours()}`.padStart(2, '0');
+        const minutes = `${date.getMinutes()}`.padStart(2, '0');
+        const seconds = `${date.getSeconds()}`.padStart(2, '0');
+
+        return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+    }
+
+    _parseDate(value) {
+        if (!value) {
+            return undefined;
+        }
+
+        const date = new Date(value);
+
+        return Number.isNaN(date.getTime()) ? undefined : date;
+    }
+
+    onIntervalChange(intervalId, field, value) {
+        const interval = this.intervals.find((item) => item.id === intervalId);
+        if (!interval) {
+            return;
+        }
+
+        interval[field] = value;
+        interval.error = undefined;
+
+        this._validateInterval(interval);
+
+        this.redraw();
+    }
+
+    _validateInterval(interval) {
+        const startedAt = this._parseDate(interval.startedAt);
+        const finishedAt = this._parseDate(interval.finishedAt);
+
+        if (!startedAt || !finishedAt) {
+            interval.error = locales.taskIntervalsModal.invalidDateMessage;
+
+            return;
+        }
+
+        if (finishedAt <= startedAt) {
+            interval.error = locales.taskIntervalsModal.invalidRangeMessage;
+
+            return;
+        }
+
+        interval.error = undefined;
+    }
+
+    _validateAll() {
+        let hasError = false;
+
+        for (const interval of this.intervals) {
+            this._validateInterval(interval);
+
+            if (interval.error) {
+                hasError = true;
+            }
+        }
+
+        return !hasError;
+    }
+
+    _getUpdatedIntervals() {
+        return this.intervals.map((interval) => ({
+            startedAt: this._parseDate(interval.startedAt),
+            finishedAt: this._parseDate(interval.finishedAt),
+        }));
+    }
+
+    onSaveClick() {
+        if (!this._validateAll()) {
+            this.redraw();
+
+            return;
+        }
+
+        if (!confirm(languageModel.t(locales.taskIntervalsModal.saveConfirm))) {
+            return;
+        }
+
+        const updatedIntervals = this._getUpdatedIntervals();
+
+        updatedIntervals.sort((left, right) => {
+            const leftTime = left.startedAt ? left.startedAt.getTime() : 0;
+            const rightTime = right.startedAt ? right.startedAt.getTime() : 0;
+
+            return leftTime - rightTime;
+        });
+
+        const newIntervals = updatedIntervals.map((interval) => new TaskIntervalModel(interval));
+        const totalMilliseconds = newIntervals.reduce((result, interval) => result + interval.durationInMilliseconds, 0);
+        const durationInSeconds = Math.round(totalMilliseconds / 1000);
+
+        this.task._finishedIntervals = newIntervals;
+        this.task._durationInSeconds = durationInSeconds;
+        this.task._startedAt = this.task._startedAt;
+
+        trackerPageModel.tasks = [...trackerPageModel.tasks];
+        trackerPageModel.updateTotalTime();
+        trackerPageModel.updateTimeOfFirstTouchToday();
+        trackerPageModel.saveToLocalStorage();
+
+        modalWindowModel.closeModal();
+    }
+
+    onCancelClick() {
+        if (!confirm(languageModel.t(locales.taskIntervalsModal.cancelConfirm))) {
+            return;
+        }
+
+        modalWindowModel.closeModal();
+    }
+
+    _renderIntervals() {
+        if (!this.intervals.length) {
+            return t`
+                <p class="task-intervals-modal__empty">${languageModel.t(locales.taskIntervalsModal.emptyState)}</p>
+            `;
+        }
+
+        return this.intervals.map((interval, index) => {
+            const error = interval.error ? t`<p class="task-intervals-modal__error">${languageModel.t(interval.error)}</p>` : '';
+
+            return t`
+                <section class="task-intervals-modal__interval" aria-labelledby="${interval.id}-label">
+                    <h2 id="${interval.id}-label">${languageModel.t(locales.taskIntervalsModal.intervalTitle)} #${index + 1}</h2>
+                    <div class="task-intervals-modal__fields">
+                        <label class="task-intervals-modal__field">
+                            <span>${languageModel.t(locales.taskIntervalsModal.startLabel)}</span>
+                            <input
+                                type="datetime-local"
+                                step="1"
+                                value="${interval.startedAt}"
+                                onchange="${(event) => this.onIntervalChange(interval.id, 'startedAt', event.target.value)}"
+                            />
+                        </label>
+                        <label class="task-intervals-modal__field">
+                            <span>${languageModel.t(locales.taskIntervalsModal.endLabel)}</span>
+                            <input
+                                type="datetime-local"
+                                step="1"
+                                value="${interval.finishedAt}"
+                                onchange="${(event) => this.onIntervalChange(interval.id, 'finishedAt', event.target.value)}"
+                            />
+                        </label>
+                    </div>
+                    ${error}
+                </section>
+            `;
+        });
+    }
+
+    toHtml() {
+        return t`
+            <dialog class="task-intervals-modal" open aria-labelledby="${this.dialogTitleId}">
+                <form class="task-intervals-modal__form" id="${this.formId}" method="dialog" novalidate>
+                    <header class="task-intervals-modal__header">
+                        <h1 id="${this.dialogTitleId}">${languageModel.t(locales.taskIntervalsModal.title)}</h1>
+                        <p class="task-intervals-modal__task">
+                            ${languageModel.t(locales.taskIntervalsModal.taskLabel)}
+                            <span>${this.task.title}</span>
+                        </p>
+                        <p class="task-intervals-modal__subtitle">${languageModel.t(locales.taskIntervalsModal.subtitle)}</p>
+                    </header>
+                    <div class="task-intervals-modal__content">
+                        ${this._renderIntervals()}
+                    </div>
+                    <footer class="task-intervals-modal__actions">
+                        <button type="button" class="task-intervals-modal__button task-intervals-modal__button--secondary" onclick="${() => this.onCancelClick()}">
+                            ${languageModel.t(locales.taskIntervalsModal.cancelButton)}
+                        </button>
+                        <button type="button" class="task-intervals-modal__button task-intervals-modal__button--primary" onclick="${() => this.onSaveClick()}">
+                            ${languageModel.t(locales.taskIntervalsModal.saveButton)}
+                        </button>
+                    </footer>
+                </form>
+            </dialog>
+        `;
+    }
+}
+
+modalWindowModel.registerModal('TaskIntervalsModalWindowComponent', TaskIntervalsModalWindowComponent);

--- a/examples/tapme/js/pages/tracker/components/task/task.component.js
+++ b/examples/tapme/js/pages/tracker/components/task/task.component.js
@@ -16,6 +16,7 @@ class TaskComponent extends Component {
                 <div class="row task-component">
                     <div>${new TaskToggleButtonComponent(this.task)}</div>
                     <div class="max-width">${new TaskTextComponent(this.task)}</div>
+                    <div class="hide-by-default">${new TaskEditIntervalsButtonComponent(this.task)}</div>
                     <div class="hide-by-default">${new TaskSaveAsPresetButtonComponent(this.task)}</div>
                     <div class="hide-by-default">
                         ${new DeleteButtonComponent(() => trackerPageModel.deleteTask(this.task))}

--- a/examples/tapme/js/pages/tracker/components/task/task.edit-intervals-button.component.js
+++ b/examples/tapme/js/pages/tracker/components/task/task.edit-intervals-button.component.js
@@ -1,0 +1,39 @@
+class TaskEditIntervalsButtonComponent extends Component {
+    /**
+     * @param {TaskModel} task
+     */
+    constructor(task) {
+        super();
+
+        this.task = task;
+
+        this.subscribe(languageModel.language).redrawOnChange();
+    }
+
+    onClick() {
+        if (this.task.isActive) {
+            return;
+        }
+
+        modalWindowModel.openModal('TaskIntervalsModalWindowComponent', { task: this.task });
+    }
+
+    toHtml() {
+        const disabled = this.task.isActive;
+
+        return t`
+            <button
+                class="icon-button icon-button--pen"
+                ${disabled && 'disabled'}
+                title="${languageModel.t(locales.taskIntervalsModal.editButtonTooltip)}"
+                aria-label="${languageModel.t(locales.taskIntervalsModal.editButtonTooltip)}"
+                onclick="${() => this.onClick()}"
+            >
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" />
+                    <path d="M20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
+                </svg>
+            </button>
+        `;
+    }
+}

--- a/examples/tapme/js/shared/const/locales.js
+++ b/examples/tapme/js/shared/const/locales.js
@@ -400,6 +400,22 @@ const locales = {
                 },
             ],
         },
+        _13: {
+            date: {
+                [Language.English]: 'September 28, 2025',
+                [Language.Russian]: '28 сентября 2025',
+                [Language.Kazakh]: '2025 жылғы 28 қыркүйек',
+                [Language.Georgian]: '2025 წლის 28 სექტემბერი',
+            },
+            lines: [
+                {
+                    [Language.English]: 'Added the ability to edit time intervals via modal window',
+                    [Language.Russian]: 'Добавлена возможность править временные интервалы через модальное окно',
+                    [Language.Kazakh]: 'Уақыт аралықтарын модальды терезе арқылы түзету мүмкіндігі қосылды',
+                    [Language.Georgian]: 'დამატებულია დროის ინტერვალების მოდალური ფანჯრიდან რედაქტირების შესაძლებლობა',
+                },
+            ],
+        },
     },
     chart: {
         chartInterval: {

--- a/examples/tapme/js/shared/const/locales.js
+++ b/examples/tapme/js/shared/const/locales.js
@@ -37,6 +37,92 @@ const locales = {
             [Language.Georgian]: 'არა, დახურე ფანჯარა',
         },
     },
+    taskIntervalsModal: {
+        title: {
+            [Language.English]: 'Edit tracked time',
+            [Language.Russian]: 'Редактировать время',
+            [Language.Kazakh]: 'Уақытты өңдеу',
+            [Language.Georgian]: 'დროის რედაქტირება',
+        },
+        taskLabel: {
+            [Language.English]: 'Task:',
+            [Language.Russian]: 'Задача:',
+            [Language.Kazakh]: 'Тапсырма:',
+            [Language.Georgian]: 'დავალება:',
+        },
+        subtitle: {
+            [Language.English]: 'Update the start and finish for every recorded interval.',
+            [Language.Russian]: 'Обновите начало и окончание каждого интервала.',
+            [Language.Kazakh]: 'Әр жазылған интервалдың басталуы мен аяқталуын жаңартыңыз.',
+            [Language.Georgian]: 'განაახლეთ თითოეული ინტერვალის დაწყება და დასრულება.',
+        },
+        intervalTitle: {
+            [Language.English]: 'Interval',
+            [Language.Russian]: 'Интервал',
+            [Language.Kazakh]: 'Интервал',
+            [Language.Georgian]: 'ინტერვალი',
+        },
+        startLabel: {
+            [Language.English]: 'Start',
+            [Language.Russian]: 'Начало',
+            [Language.Kazakh]: 'Басталу',
+            [Language.Georgian]: 'დაწყება',
+        },
+        endLabel: {
+            [Language.English]: 'End',
+            [Language.Russian]: 'Окончание',
+            [Language.Kazakh]: 'Аяқталу',
+            [Language.Georgian]: 'დასრულება',
+        },
+        saveButton: {
+            [Language.English]: 'Save',
+            [Language.Russian]: 'Сохранить',
+            [Language.Kazakh]: 'Сақтау',
+            [Language.Georgian]: 'შენახვა',
+        },
+        cancelButton: {
+            [Language.English]: 'Cancel',
+            [Language.Russian]: 'Отмена',
+            [Language.Kazakh]: 'Бас тарту',
+            [Language.Georgian]: 'გაუქმება',
+        },
+        saveConfirm: {
+            [Language.English]: 'Save the updated timestamps?',
+            [Language.Russian]: 'Сохранить изменённые отметки времени?',
+            [Language.Kazakh]: 'Жаңартылған уақыттарды сақтау керек пе?',
+            [Language.Georgian]: 'შევინახო განახლებული დროები?',
+        },
+        cancelConfirm: {
+            [Language.English]: 'Discard changes and close the window?',
+            [Language.Russian]: 'Отменить изменения и закрыть окно?',
+            [Language.Kazakh]: 'Өзгерістерден бас тартып, терезені жабу керек пе?',
+            [Language.Georgian]: 'გავაუქმო ცვლილებები და დავხურო ფანჯარა?',
+        },
+        invalidDateMessage: {
+            [Language.English]: 'Enter both start and end date and time.',
+            [Language.Russian]: 'Укажите дату и время начала и окончания.',
+            [Language.Kazakh]: 'Басталу және аяқталу күні мен уақытын енгізіңіз.',
+            [Language.Georgian]: 'შეიყვანეთ დაწყების და დასრულების თარიღი და დრო.',
+        },
+        invalidRangeMessage: {
+            [Language.English]: 'End time must be later than the start time.',
+            [Language.Russian]: 'Время окончания должно быть позже времени начала.',
+            [Language.Kazakh]: 'Аяқталу уақыты басталу уақытынан кейін болуы тиіс.',
+            [Language.Georgian]: 'დასრულება უნდა იყოს დაწყებაზე გვიან.',
+        },
+        emptyState: {
+            [Language.English]: 'This task does not have recorded intervals yet.',
+            [Language.Russian]: 'У задачи пока нет сохранённых интервалов.',
+            [Language.Kazakh]: 'Бұл тапсырмада сақталған интервалдар жоқ.',
+            [Language.Georgian]: 'ამ ამოცანას ჯერ არ აქვს შენახული ინტერვალები.',
+        },
+        editButtonTooltip: {
+            [Language.English]: 'Edit recorded time',
+            [Language.Russian]: 'Редактировать время',
+            [Language.Kazakh]: 'Уақытты өңдеу',
+            [Language.Georgian]: 'დროის რედაქტირება',
+        },
+    },
     trackerSettings: {
         title: {
             [Language.English]: 'Settings',


### PR DESCRIPTION
## Summary
- add an edit button to tracker tasks that opens a dialog for adjusting recorded time intervals
- implement a task interval editor modal with localized labels, validation, and confirmations for saving or canceling changes
- update styles, imports, and locale strings to support the new dialog and disabled pen icon state

## Testing
- Manual UI verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d735b42b008326aee928bbd2fce3ae